### PR TITLE
python: bump pyproject.toml depend python version 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["randymcmillan <randy.lee.mcmillan@gmail.com>, bitkarrot <bitkarrot@b
 license = "Apache License 2.0"
 
 [tool.poetry.dependencies]
-python = "^3.7.1"
+python = "^3.8"
 pre-commit = "2.13.0"
 aiohttp = "3.7.4.post0"
 PyYAML = "5.4.1"


### PR DESCRIPTION
@bitkarrot - I would prefer to bump this python version to 3.8 - this will ensure that the CI is testing the lowest supported version - If there is no objections.

If there is anywhere else the version needs to be bumped to 3.8 - please mention it. 


The CI matrix here -> https://github.com/0x20bf-org/0x20bf/actions/runs/1907170983 